### PR TITLE
fix bug in uprading clusternet-hub and clusternet-agent

### DIFF
--- a/charts/clusternet-agent/Chart.yaml
+++ b/charts/clusternet-agent/Chart.yaml
@@ -33,7 +33,7 @@ kubeVersion: ""
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.4
+version: 0.12.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusternet-agent/templates/bootstrap_rbac.yaml
+++ b/charts/clusternet-agent/templates/bootstrap_rbac.yaml
@@ -90,7 +90,7 @@ subjects:
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: clusternet:app:deployer
+  name: clusternet:app:deployer:admin
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/charts/clusternet-controller-manager/Chart.yaml
+++ b/charts/clusternet-controller-manager/Chart.yaml
@@ -31,7 +31,7 @@ kubeVersion: ""
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.4
+version: 0.12.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusternet-hub/Chart.yaml
+++ b/charts/clusternet-hub/Chart.yaml
@@ -31,7 +31,7 @@ kubeVersion: ""
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.4
+version: 0.12.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clusternet-hub/templates/clusterrolebinding.yaml
+++ b/charts/clusternet-hub/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: clusternet:hub
+  name: clusternet:hub:admin
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/charts/clusternet-scheduler/Chart.yaml
+++ b/charts/clusternet-scheduler/Chart.yaml
@@ -33,7 +33,7 @@ kubeVersion: ""
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.4
+version: 0.12.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Kubernetes doesn't allow RoleRef of ClusterRoleBinding(or RoleBinding) to be updated

Change name of clusterrolebinding, to keep uprading smoothly